### PR TITLE
Small UI Tweaks: Default Rewatching, Consistent Category Colors, Collapsable Settings & Persist View Mode

### DIFF
--- a/.claude/skills/ani-debug/SKILL.md
+++ b/.claude/skills/ani-debug/SKILL.md
@@ -41,6 +41,18 @@ Look for rapid back-and-forth flips (sub-second Content↔InitialLoading, or Con
 ### NAVTRACE
 Navigation phase timings. `details load finished in Nms` > ~1500ms indicates the details-page fetch is blocking visible rendering. `ApplyQueryAttributes → OnAppearing` gap > 300ms suggests Shell transition contention.
 
+### LIFECYCLE (app log, Android-only)
+`LIFECYCLE MainActivity[#<hash>] On<Phase>` marks Android Activity lifecycle transitions. The `#hash` is `GetHashCode()` of the Activity instance — if the hash changes across a background cycle, the process survived but the Activity was destroyed and recreated (the classic trigger for stale `FragmentActivity` captures inside MAUI views). An `OnDestroy (isFinishing=False)` followed by a fresh `OnCreate` with a different hash confirms this.
+
+### LOADEDHOST (app log)
+`LOADEDHOST <Page> attach|detach (...)` brackets every write to `LoadedContentHost.Content` on `MyAnimePage` / `MediaDetailsPage` / `SettingsPage`. Correlate with Glide "destroyed activity" timestamps: the attach immediately preceding the cascade is the one that instantiated the Loaded*ContentView against a stale Activity. Repeated attach→detach→attach within ~1s indicates a state-flip feedback loop (usually auth-related).
+
+### LOADEDVIEW (app log)
+`LOADEDVIEW <Page>[#<hash>] constructed | OnHandlerChanged | RecyclerView handler attached (contextHash=#...)`. The `#hash` is per-view-instance; a new hash on each `LOADEDHOST attach` means the view is being fully re-materialized (cheap to log, expensive at runtime — triggers InitializeComponent, CollectionView rebind, font-icon Glide loads). The `RecyclerView contextHash` is the FragmentActivity Glide will capture — compare against the current `LIFECYCLE MainActivity` hash: mismatch confirms stale capture.
+
+### AUTH token-check (app log)
+`AUTH token-check: absent | expired, signing out | valid` fires at every `AuthService.GetAccessTokenAsync` call. The "expired, signing out" path wipes SecureStorage and flips `IsAuthenticated` to false — a routine token-refresh check becoming a full sign-out. On resume after background, this is the common trigger for `PageState: Content → Unauthenticated → InitialLoading → Content`.
+
 ## Drill-in
 
 When the summary flags something, go deeper without re-running the collector:

--- a/src/MauiProgram.cs
+++ b/src/MauiProgram.cs
@@ -39,8 +39,11 @@ public static class MauiProgram
         builder.Logging.AddFilter("Microsoft", LogLevel.Warning);
         builder.Logging.AddFilter("System", LogLevel.Warning);
         builder.Logging.AddFilter("Sentry", LogLevel.Warning);
-        builder.Logging.AddProvider(new FileLoggerProvider(logDirectory, minimumLevel: LogLevel.Information));
-        builder.Logging.AddFilter<FileLoggerProvider>(string.Empty, LogLevel.Information);
+        // Debug-level app logs are intentionally kept on for pre-production development
+        // (solo-dev install). Re-evaluate before first public release. Framework namespaces
+        // (Microsoft/System/Sentry) stay capped at Warning to avoid firehose output.
+        builder.Logging.AddProvider(new FileLoggerProvider(logDirectory, minimumLevel: LogLevel.Debug));
+        builder.Logging.AddFilter<FileLoggerProvider>(string.Empty, LogLevel.Debug);
         builder.Logging.AddFilter<FileLoggerProvider>("Microsoft", LogLevel.Warning);
         builder.Logging.AddFilter<FileLoggerProvider>("System", LogLevel.Warning);
         builder.Logging.AddFilter<FileLoggerProvider>("Sentry", LogLevel.Warning);

--- a/src/PageModels/MediaDetailsPageModel.cs
+++ b/src/PageModels/MediaDetailsPageModel.cs
@@ -422,6 +422,10 @@ namespace AniSprinkles.PageModels;
         var loadRequestId = Interlocked.Increment(ref _loadRequestSequence);
         var loadStopwatch = Stopwatch.StartNew();
 
+        _logger.LogInformation(
+            "MediaDetails LoadAsync enter load#{LoadRequestId} (mediaId={MediaId}, isBusy={IsBusy}, currentState={CurrentState}, loadedMediaId={LoadedMediaId}, hasListEntry={HasListEntry})",
+            loadRequestId, mediaId, IsBusy, CurrentState, _loadedMediaId, listEntry is not null);
+
         if (IsBusy)
         {
             _logger.LogInformation("NAVTRACE load#{LoadRequestId} skipped because details view model is already busy.", loadRequestId);

--- a/src/PageModels/MyAnimePageModel.cs
+++ b/src/PageModels/MyAnimePageModel.cs
@@ -154,8 +154,13 @@ public partial class MyAnimePageModel : ObservableObject
 
     public async Task LoadAsync(bool forceReload = false)
     {
+        _logger.LogInformation(
+            "MyAnime LoadAsync enter (forceReload={ForceReload}, isBusy={IsBusy}, hasLoaded={HasLoaded}, currentState={CurrentState}, hadSections={HadSections})",
+            forceReload, IsBusy, _hasLoaded, CurrentState, Sections.Count);
+
         if (IsBusy)
         {
+            _logger.LogInformation("MyAnime LoadAsync skipped: already busy.");
             return;
         }
 

--- a/src/PageModels/SettingsPageModel.cs
+++ b/src/PageModels/SettingsPageModel.cs
@@ -157,6 +157,10 @@ public partial class SettingsPageModel : ObservableObject
         // On refresh-with-cached-data the content view is already visible;
         // flipping CurrentState would overlay the spinner on top of it.
         var isRefresh = _loadedUser is not null;
+        _logger.LogInformation(
+            "Settings LoadAsync enter (isRefresh={IsRefresh}, currentState={CurrentState}, isAuthenticated={IsAuthenticated})",
+            isRefresh, CurrentState, IsAuthenticated);
+
         if (!isRefresh)
         {
             CurrentState = PageState.InitialLoading;

--- a/src/Pages/MediaDetailsPage.xaml.cs
+++ b/src/Pages/MediaDetailsPage.xaml.cs
@@ -226,6 +226,9 @@ public partial class MediaDetailsPage : ContentPage, IQueryAttributable
             {
                 try
                 {
+                    Logger.LogInformation(
+                        "LOADEDHOST MediaDetails attach (hasMedia={HasMedia}, isBusy={IsBusy}, currentState={CurrentState})",
+                        ViewModel.HasMedia, ViewModel.IsBusy, ViewModel.CurrentState);
                     // Keep first navigation frame lightweight: create the heavy details subtree only after
                     // data has loaded, so the user sees the loading page instantly.
                     LoadedContentHost.Content = new Views.MediaDetailsLoadedContentView
@@ -248,6 +251,9 @@ public partial class MediaDetailsPage : ContentPage, IQueryAttributable
         }
         else if (_hasCreatedLoadedContent)
         {
+            Logger.LogInformation(
+                "LOADEDHOST MediaDetails detach (hasMedia={HasMedia}, isBusy={IsBusy}, currentState={CurrentState})",
+                ViewModel.HasMedia, ViewModel.IsBusy, ViewModel.CurrentState);
             LoadedContentHost.Content = null;
             _hasCreatedLoadedContent = false;
         }

--- a/src/Pages/MyAnimePage.xaml.cs
+++ b/src/Pages/MyAnimePage.xaml.cs
@@ -1,6 +1,7 @@
 using AniSprinkles.PageModels;
 using AniSprinkles.Utilities;
 using IconFont.Maui.FluentIcons;
+using Microsoft.Extensions.Logging;
 
 namespace AniSprinkles.Pages;
 
@@ -14,6 +15,7 @@ public partial class MyAnimePage : ContentPage
     private int _loadVersion;
     private readonly ToolbarItem? _searchToolbarItem;
     private readonly ToolbarItem? _viewModeToolbarItem;
+    private readonly ILogger<MyAnimePage>? _logger;
 
     public MyAnimePage()
     {
@@ -21,6 +23,15 @@ public partial class MyAnimePage : ContentPage
         // Stash toolbar items so we can add/remove them based on auth state.
         _searchToolbarItem = SearchToolbarItem;
         _viewModeToolbarItem = ViewModeToolbarItem;
+
+        try
+        {
+            _logger = ServiceProviderHelper.GetServiceProvider()
+                .GetService<ILoggerFactory>()?.CreateLogger<MyAnimePage>();
+        }
+        catch (InvalidOperationException)
+        {
+        }
     }
 
     public MyAnimePage(MyAnimePageModel viewModel)
@@ -119,19 +130,26 @@ public partial class MyAnimePage : ContentPage
     private void UpdateLoadedContentHost()
     {
         var isError = _viewModel?.CurrentState == PageState.Error;
+        var isAuth = _viewModel?.IsAuthenticated == true;
 
-        if (_viewModel?.IsAuthenticated == true && !isError && !_hasCreatedLoadedContent)
+        if (isAuth && !isError && !_hasCreatedLoadedContent)
         {
             var view = new Views.MyAnimeLoadedContentView
             {
                 BindingContext = _viewModel
             };
 
+            _logger?.LogInformation(
+                "LOADEDHOST MyAnime attach (isAuth={IsAuth}, isError={IsError}, currentState={CurrentState})",
+                isAuth, isError, _viewModel?.CurrentState);
             LoadedContentHost.Content = view;
             _hasCreatedLoadedContent = true;
         }
-        else if ((_viewModel?.IsAuthenticated != true || isError) && _hasCreatedLoadedContent)
+        else if ((!isAuth || isError) && _hasCreatedLoadedContent)
         {
+            _logger?.LogInformation(
+                "LOADEDHOST MyAnime detach (isAuth={IsAuth}, isError={IsError}, currentState={CurrentState})",
+                isAuth, isError, _viewModel?.CurrentState);
             LoadedContentHost.Content = null;
             _hasCreatedLoadedContent = false;
         }

--- a/src/Pages/SettingsPage.xaml.cs
+++ b/src/Pages/SettingsPage.xaml.cs
@@ -1,4 +1,6 @@
 using AniSprinkles.PageModels;
+using AniSprinkles.Utilities;
+using Microsoft.Extensions.Logging;
 
 namespace AniSprinkles.Pages;
 
@@ -10,10 +12,20 @@ public partial class SettingsPage : ContentPage
     private bool _hasAppeared;
     private bool _hasCreatedLoadedContent;
     private int _loadVersion;
+    private readonly ILogger<SettingsPage>? _logger;
 
     public SettingsPage()
     {
         InitializeComponent();
+
+        try
+        {
+            _logger = ServiceProviderHelper.GetServiceProvider()
+                .GetService<ILoggerFactory>()?.CreateLogger<SettingsPage>();
+        }
+        catch (InvalidOperationException)
+        {
+        }
     }
 
     public SettingsPage(SettingsPageModel viewModel)
@@ -112,6 +124,9 @@ public partial class SettingsPage : ContentPage
 
         if (shouldShow && !_hasCreatedLoadedContent)
         {
+            _logger?.LogInformation(
+                "LOADEDHOST Settings attach (isAuth={IsAuth}, currentState={CurrentState})",
+                _viewModel?.IsAuthenticated, _viewModel?.CurrentState);
             LoadedContentHost.Content = new Views.SettingsLoadedContentView
             {
                 BindingContext = _viewModel
@@ -120,6 +135,9 @@ public partial class SettingsPage : ContentPage
         }
         else if (!shouldShow && _hasCreatedLoadedContent)
         {
+            _logger?.LogInformation(
+                "LOADEDHOST Settings detach (isAuth={IsAuth}, currentState={CurrentState})",
+                _viewModel?.IsAuthenticated, _viewModel?.CurrentState);
             LoadedContentHost.Content = null;
             _hasCreatedLoadedContent = false;
         }

--- a/src/Platforms/Android/MainActivity.cs
+++ b/src/Platforms/Android/MainActivity.cs
@@ -23,9 +23,15 @@ namespace AniSprinkles;
         ConfigChanges.Density)]
 public class MainActivity : MauiAppCompatActivity
 {
+    private const string LifecycleTag = "AniSprinklesLifecycle";
+
+    private string ActivityIdentity
+        => $"MainActivity[#{GetHashCode():X}]";
+
     protected override void OnCreate(Bundle? savedInstanceState)
     {
         base.OnCreate(savedInstanceState);
+        Log.Info(LifecycleTag, $"LIFECYCLE {ActivityIdentity} OnCreate (savedInstanceState={(savedInstanceState is null ? "null" : "present")})");
 
         // Catch unhandled exceptions from Java/Android side
         Android.Runtime.AndroidEnvironment.UnhandledExceptionRaiser += (sender, args) =>
@@ -92,6 +98,36 @@ public class MainActivity : MauiAppCompatActivity
         {
             Log.Error(nameof(MainActivity), $"Error in OnCreate: {ex.Message}");
         }
+    }
+
+    protected override void OnStart()
+    {
+        base.OnStart();
+        Log.Info(LifecycleTag, $"LIFECYCLE {ActivityIdentity} OnStart");
+    }
+
+    protected override void OnResume()
+    {
+        base.OnResume();
+        Log.Info(LifecycleTag, $"LIFECYCLE {ActivityIdentity} OnResume");
+    }
+
+    protected override void OnPause()
+    {
+        Log.Info(LifecycleTag, $"LIFECYCLE {ActivityIdentity} OnPause");
+        base.OnPause();
+    }
+
+    protected override void OnStop()
+    {
+        Log.Info(LifecycleTag, $"LIFECYCLE {ActivityIdentity} OnStop");
+        base.OnStop();
+    }
+
+    protected override void OnDestroy()
+    {
+        Log.Info(LifecycleTag, $"LIFECYCLE {ActivityIdentity} OnDestroy (isFinishing={IsFinishing})");
+        base.OnDestroy();
     }
 
     private int GetWindowBackgroundColor()

--- a/src/Services/AuthService.cs
+++ b/src/Services/AuthService.cs
@@ -26,13 +26,20 @@ public class AuthService : IAuthService
             await LoadAsync(cancellationToken);
         }
 
+        if (AccessToken is null)
+        {
+            _logger.LogInformation("AUTH token-check: absent (no token in SecureStorage).");
+            return null;
+        }
+
         if (IsExpired())
         {
-            _logger.LogInformation("AniList access token expired.");
+            _logger.LogInformation("AUTH token-check: expired (expiresAt={ExpiresAt}), signing out.", ExpiresAt);
             await SignOutAsync();
             return null;
         }
 
+        _logger.LogInformation("AUTH token-check: valid (expiresAt={ExpiresAt}).", ExpiresAt);
         return AccessToken;
     }
 

--- a/src/Views/MediaDetailsLoadedContentView.xaml.cs
+++ b/src/Views/MediaDetailsLoadedContentView.xaml.cs
@@ -1,9 +1,37 @@
+using System.Runtime.CompilerServices;
+using AniSprinkles.Utilities;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 namespace AniSprinkles.Views;
 
 public partial class MediaDetailsLoadedContentView : ContentView
 {
+    private readonly ILogger<MediaDetailsLoadedContentView>? _logger;
+    private readonly int _viewId;
+
     public MediaDetailsLoadedContentView()
     {
         InitializeComponent();
+
+        _viewId = RuntimeHelpers.GetHashCode(this);
+        try
+        {
+            _logger = ServiceProviderHelper.GetServiceProvider()
+                .GetService<ILoggerFactory>()?.CreateLogger<MediaDetailsLoadedContentView>();
+        }
+        catch (InvalidOperationException)
+        {
+        }
+
+        _logger?.LogInformation("LOADEDVIEW MediaDetails[#{ViewId:X}] constructed", _viewId);
+    }
+
+    protected override void OnHandlerChanged()
+    {
+        base.OnHandlerChanged();
+        _logger?.LogInformation(
+            "LOADEDVIEW MediaDetails[#{ViewId:X}] OnHandlerChanged (handler={HasHandler})",
+            _viewId, Handler is not null);
     }
 }

--- a/src/Views/MyAnimeLoadedContentView.xaml.cs
+++ b/src/Views/MyAnimeLoadedContentView.xaml.cs
@@ -1,4 +1,8 @@
 using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using AniSprinkles.Utilities;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace AniSprinkles.Views;
 
@@ -7,6 +11,8 @@ public partial class MyAnimeLoadedContentView : ContentView
     private readonly DataTemplate? _standardTemplate;
     private readonly DataTemplate? _largeTemplate;
     private readonly DataTemplate? _compactTemplate;
+    private readonly ILogger<MyAnimeLoadedContentView>? _logger;
+    private readonly int _viewId;
     private bool _longPressFired;
 
     public MyAnimeLoadedContentView()
@@ -16,7 +22,28 @@ public partial class MyAnimeLoadedContentView : ContentView
         _largeTemplate = (DataTemplate)Resources["LargeItemTemplate"];
         _compactTemplate = (DataTemplate)Resources["CompactItemTemplate"];
 
+        _viewId = RuntimeHelpers.GetHashCode(this);
+        try
+        {
+            _logger = ServiceProviderHelper.GetServiceProvider()
+                .GetService<ILoggerFactory>()?.CreateLogger<MyAnimeLoadedContentView>();
+        }
+        catch (InvalidOperationException)
+        {
+            // DI not ready; logging is optional instrumentation.
+        }
+
+        _logger?.LogInformation("LOADEDVIEW MyAnime[#{ViewId:X}] constructed", _viewId);
+
         AnimeCollectionView.HandlerChanged += OnCollectionViewHandlerChanged;
+    }
+
+    protected override void OnHandlerChanged()
+    {
+        base.OnHandlerChanged();
+        _logger?.LogInformation(
+            "LOADEDVIEW MyAnime[#{ViewId:X}] OnHandlerChanged (handler={HasHandler})",
+            _viewId, Handler is not null);
     }
 
     private void OnItemTapped(object? sender, TappedEventArgs e)
@@ -70,8 +97,21 @@ public partial class MyAnimeLoadedContentView : ContentView
         var recyclerView = platformView as AndroidX.RecyclerView.Widget.RecyclerView;
         if (recyclerView is null)
         {
+            _logger?.LogInformation(
+                "LOADEDVIEW MyAnime[#{ViewId:X}] RecyclerView handler change (platformView=null).",
+                _viewId);
             return;
         }
+
+        // Capture the RecyclerView's Context identity. This is the Android FragmentActivity
+        // that Glide captures when binding images in each cell. If the hash ever differs from
+        // the current MainActivity hash (see LIFECYCLE logs), we've captured a destroyed activity.
+        var ctx = recyclerView.Context;
+        _logger?.LogInformation(
+            "LOADEDVIEW MyAnime[#{ViewId:X}] RecyclerView handler attached (contextType={ContextType}, contextHash=#{ContextHash:X})",
+            _viewId,
+            ctx?.GetType().Name ?? "null",
+            ctx is null ? 0 : ctx.GetHashCode());
 
         var gestureDetector = new Android.Views.GestureDetector(
             recyclerView.Context,

--- a/src/Views/SettingsLoadedContentView.xaml.cs
+++ b/src/Views/SettingsLoadedContentView.xaml.cs
@@ -1,9 +1,37 @@
+using System.Runtime.CompilerServices;
+using AniSprinkles.Utilities;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
 namespace AniSprinkles.Views;
 
 public partial class SettingsLoadedContentView : ContentView
 {
+    private readonly ILogger<SettingsLoadedContentView>? _logger;
+    private readonly int _viewId;
+
     public SettingsLoadedContentView()
     {
         InitializeComponent();
+
+        _viewId = RuntimeHelpers.GetHashCode(this);
+        try
+        {
+            _logger = ServiceProviderHelper.GetServiceProvider()
+                .GetService<ILoggerFactory>()?.CreateLogger<SettingsLoadedContentView>();
+        }
+        catch (InvalidOperationException)
+        {
+        }
+
+        _logger?.LogInformation("LOADEDVIEW Settings[#{ViewId:X}] constructed", _viewId);
+    }
+
+    protected override void OnHandlerChanged()
+    {
+        base.OnHandlerChanged();
+        _logger?.LogInformation(
+            "LOADEDVIEW Settings[#{ViewId:X}] OnHandlerChanged (handler={HasHandler})",
+            _viewId, Handler is not null);
     }
 }


### PR DESCRIPTION
## Description
A collection of small UI/UX improvements to enhance the visual clarity, user experience, and app state persistence.

## Requested Changes

1. **Rewatching section should be open by default**
   - Currently, the "Rewatching" status category is collapsed by default
   - Should be expanded by default to match the behavior of the "Watching" category
   - Improves discoverability of actively rewatched titles

2. **Unique colors for status categories**
   - Several status categories currently share the same colors due to random color generation
   - Should hardcode distinct colors for each status category:
     - Watching
     - Completed
     - Paused
     - Dropped
     - Planning
     - Rewatching
   - Improves visual organization and makes it easier to distinguish between categories at a glance

3. **Collapsible sections in Settings**
   - Consider organizing Settings page into collapsible sections
   - Would improve navigation for users with many settings
   - Could group related settings together (e.g., Display, Notifications, About)

4. **Persist My Anime page view mode**
   - Currently, when the user changes the view (e.g., from list to grid or adjusts icon size)
   - The preference is not saved across app sessions
   - When the app is closed and reopened, the view reverts to the default
   - Should persist the user's chosen view mode, layout, and icon size between sessions
   - Improves continuity and user preference retention

## Acceptance Criteria
- [ ] Rewatching section opens by default on app launch / when navigating to My Anime
- [ ] All status categories have unique, hardcoded colors
- [ ] Settings layout remains clean and usable with current options
- [ ] My Anime page view mode is persisted across app sessions