### PR TITLE
Add /run-anisprinkles and /ani-kickoff workflow skills

### DIFF
--- a/.claude/skills/ani-kickoff/SKILL.md
+++ b/.claude/skills/ani-kickoff/SKILL.md
@@ -1,0 +1,294 @@
+---
+name: ani-kickoff
+description: "Start work on a GitHub issue the right way: pull the issue, verify it isn't stale or already fixed, analyze solutions independently of whatever the issue proposes, surface tradeoffs, ask clarifying questions, and agree a plan before any code exists. Use whenever the user names issue numbers to work on — \"let's do #112\", \"start issue 63\", \"pick up 52 and 62\" — or asks to take something off the backlog. Prefer this over jumping straight into implementation, even when the issue looks obvious."
+argument-hint: "<issue number> [more issue numbers]"
+allowed-tools: Bash(gh *) Bash(git *) Read Grep Glob AskUserQuestion ExitPlanMode
+---
+
+# Ani-kickoff
+
+Kicking off: $ARGUMENTS
+
+The point of this skill is to spend thinking time where it is cheap. A wrong
+assumption costs seconds to fix while it is still a sentence in a plan, and hours
+once it is code with tests and a PR built on top of it. So the order here is
+deliberately: understand → verify → analyze → ask → agree → *then* branch.
+
+Nothing gets implemented during this skill. It ends at an approved plan and a
+branch to build it on.
+
+---
+
+## Step 1 — Load the issues
+
+```bash
+gh issue view <N> --json number,title,state,body,labels,createdAt,updatedAt,closedAt,comments \
+  --template '#{{.number}} {{.title}} [{{.state}}] created={{.createdAt}} updated={{.updatedAt}} comments={{len .comments}}{{"\n"}}labels:{{range .labels}} {{.name}}{{end}}{{"\n"}}---{{"\n"}}{{.body}}'
+```
+
+Read the comments too — they often contain the decision that the body never got
+updated to reflect.
+
+Issue bodies in this repo vary wildly in density, and that difference should
+change how you work:
+
+- **Sparse** (#112 is two sentences: "we should have some kind of setting or
+  something") — nearly every requirement is unstated. Most of your effort belongs
+  in Step 4, and you should expect to ask a lot.
+- **Dense** (#63 has Background / Problem / Options with a recommended option and
+  its tradeoffs) — the thinking is already on the page. Your job shifts to
+  pressure-testing it rather than generating it from scratch. It is still a
+  hypothesis, not a spec; see Step 3.
+
+**Check `state` first.** A closed issue is the fastest possible staleness result,
+and it happens — a batch like "let's do 14 and 56" can easily contain one that
+shipped months ago. If it is `CLOSED`, say so immediately with the close date,
+and ask whether they meant a different number or want to reopen the topic. Don't
+plan work for it on the assumption they know.
+
+---
+
+## Step 2 — Verify the issue is still real
+
+This is the step that earns the skill its keep. Issues in this repo go stale in
+recognizable ways, so work through these deliberately rather than trusting the
+issue's framing:
+
+**Search broadly before concluding anything.** This is the failure mode that will
+burn you, so internalize it before the specific checks below: an empty search
+result is not evidence of absence, it is usually evidence you guessed the wrong
+word. Real examples from this repo — grepping `IsExpanded` found nothing and
+nearly got shipped work reported as unbuilt, because the code says
+`IsDisplayPreferencesExpanded`; `gh issue list --search "unit test PageModel
+Services Converters"` returned one issue while `--search "unit test"` returned
+three, including the one that mattered.
+
+So: start with the shortest query that could plausibly match, then narrow. Try at
+least two phrasings before believing a negative. When you do report something as
+missing, say what you searched for, so the user can spot a wrong guess.
+
+**Already fixed, wholly or partly.** Search for the symbols, files, or behavior
+the issue names, and check history since it was filed:
+
+```bash
+git log --oneline --since=<issue createdAt> --grep=<keyword> -i
+git log --format='%h %ad %s' --date=short -S "<code snippet>" -- <path>
+gh pr list --state all --search "<keyword>" --limit 5 --json number,title,state \
+  --template '{{range .}}#{{.number}} [{{.state}}] {{.title}}{{"\n"}}{{end}}'
+```
+
+`git log -S` is the more reliable of the two log commands — it finds the commit
+where a string actually entered or left the code, regardless of what the commit
+message claimed.
+
+Partial completion is the common case and the easy one to miss — half the issue
+shipped, the remainder is still valid but the framing no longer matches reality.
+
+**Superseded by a documented decision — but date it before you believe it.**
+Docs that explain why the code is the way it is look like decisions to keep it
+that way, and often aren't. Find when the documentation was written and compare
+that to when the issue was filed:
+
+```bash
+git log --format='%h %ad %s' --date=short -S "<phrase from the doc>" -- AGENTS.md
+```
+
+The distinction that matters: documentation written *after* an issue, by someone
+who knew about it, is a decision. Documentation written *alongside the very work
+the issue is following up on* is just a description of the gap — which is what
+the issue is already telling you.
+
+#63 is the cautionary case. It asks to move `AiringCheckWorker` off
+`Android.Util.Log`, and AGENTS.md explains that call site as an intentional
+exception, which reads like the issue was overruled. It wasn't: the AGENTS.md
+paragraph and the worker's inline comment both landed in `b96e96c` — PR #61, the
+same PR whose unfinished scope #63 was filed to track, merged one day *after*
+it. The doc is saying "here's why we haven't done this yet," not "we decided not
+to." #63 is entirely live.
+
+Treat this as the general lesson rather than a fact about #63: an explanation of
+the status quo is not consent to it, and the timestamps will tell you which one
+you are looking at.
+
+**Duplicate or overlapping open issues.** Search the whole issue list, not just
+open ones:
+
+```bash
+gh issue list --state all --search "<topic>" --limit 8 --json number,title,state \
+  --template '{{range .}}#{{.number}} [{{.state}}] {{.title}}{{"\n"}}{{end}}'
+```
+
+What you are looking for is not only exact duplicates but **dependency order**,
+which is easier to miss and more expensive to get wrong. #62 ("Extract
+AniSprinkles.Core class library") is the precondition for the highest-value
+phase of #52 ("Add unit test suite for PageModels, Services, and Converters") —
+planning #52 without noticing that means planning work that cannot start.
+
+Report the relationship you actually found rather than rounding it to
+"duplicate": *blocks*, *overlaps in part*, *supersedes*, and *duplicates* lead to
+different recommendations.
+
+**The premise moved.** The architecture may have changed underneath the issue.
+#64 proposes investigating `ItemSizingStrategy` for CollectionView perf, but
+those lists were since migrated from `BindableLayout` to virtualized
+`CollectionView`s, which is most of what that investigation was chasing. Read
+`/project-architecture` and the relevant source before accepting the issue's
+description of how things currently work.
+
+**The unstated assumption.** Most issues quietly assume some mechanism already
+behaves a certain way, and the assumption is worth checking directly — it is
+where the highest-value findings hide, precisely because nobody wrote it down to
+be questioned. Pay particular attention to behavior that differs between Debug
+and Release, since this repo diverges meaningfully across them (file-log level
+and size, CI stub services, `AddDebug()` wiring).
+
+#112 asks for a button to send diagnostic logs. The unstated assumption is that
+the log file contains diagnostics — but Release persists only `Warning` and
+above while every trace in the app (`NAVTRACE`, `PageState`, `CACHE`, `AUTH`) is
+`Information`, so the shipped button would deliver a file missing exactly what
+makes a report useful. That reframes the whole issue, and it is invisible unless
+you go looking.
+
+**External blockers.** For anything labeled `blocked`, or that depends on a
+package or platform version, confirm the blocker's current status rather than
+assuming — both that it is still blocking, and that it hasn't quietly resolved.
+
+**Report before planning.** When you find staleness, stop and lay it out: what
+specifically changed, the commit / PR / doc that changed it, how much of the
+issue survives, and your recommendation (close it, narrow it, merge it with
+another, or proceed as written). Then ask what they want to do. Cite evidence
+rather than impressions — "this looks outdated" is not actionable; "PR #61
+shipped the logger provider but not the worker migration, so the second half is
+still valid" is.
+
+---
+
+## Step 3 — Work out the right solution
+
+If the issue proposes a solution, treat it as a well-informed hypothesis from
+someone who had context you may lack — worth taking seriously, not worth
+adopting unexamined. It was written before the code was, and the codebase has
+opinions.
+
+Come up with at least one genuine alternative before settling. If the issue's
+option really is best, saying *why* it beat the alternative is far more useful
+than saying it was the only thing considered.
+
+Check candidate approaches against the conventions that actually bite here:
+
+- **DI lifetimes** — services and flyout PageModels are singleton; pages and
+  details PageModels are transient. Getting this wrong produces state that leaks
+  across navigations or is silently discarded. See `/project-architecture`.
+- **Navigation** — routes plus lightweight query params, never full objects.
+- **Rate-limit budget** — new AniList reads are expensive. Batch with GraphQL
+  aliases where you can, and be honest in the plan about how many requests an
+  approach adds. See the AniList section of `AGENTS.md`.
+- **CI stub counterpart** — any new `IAniListClient` operation needs its
+  `CIAniListClient` twin, or the CI screenshot job breaks. Easy to forget, and it
+  fails well after the fact.
+- **Zero warnings** — the build must stay clean.
+- **Testability** — `tests/` link-compiles individual files from `src/` rather
+  than referencing the MAUI app, so what is practically testable is constrained.
+  If an approach is untestable under that setup, that is a real tradeoff to name.
+
+Name the tradeoffs plainly, including the ones that argue against your own
+recommendation. Flag anything that is hard to reverse, touches auth or tokens,
+or changes on-device behavior you cannot verify from the desktop.
+
+---
+
+## Step 4 — Ask clarifying questions
+
+The user's explicit goal is to fix it right the first time, which means questions
+are welcome — but their value comes from being answerable and consequential, not
+from their quantity.
+
+Ask about anything where two readings lead to genuinely different code. Skip
+anything you can settle yourself by reading the codebase; burning a question on
+something greppable spends the user's attention badly and makes the real
+questions easier to skim past.
+
+Good questions tend to be grounded in something specific you found: "the issue
+says diagnostic logs should be sendable — the file logger keeps 3 rotated
+archives at `{AppDataDirectory}/logs/`; should the share include all of them or
+just the current one?" beats "how should logging work?"
+
+Worth probing on most issues:
+
+- Scope edges — what is explicitly *not* in this change
+- What "done" looks like, concretely enough to verify on device
+- Whether it needs a settings toggle, or is always-on
+- Existing behavior that may be relied on and shouldn't change
+- Whether it should work signed-out (much of the app does)
+
+Use `AskUserQuestion` for these rather than listing them in prose — it is the
+project convention, and it makes them far easier to answer in one pass. Batch
+related questions into a single call instead of trickling them out one at a
+time. If a question has an obvious sensible default, offer it as the recommended
+option so answering is cheap.
+
+---
+
+## Step 5 — Present the plan and get approval
+
+Present the plan in the conversation and end at an explicit approval gate
+(`ExitPlanMode`) so nothing gets built before the user has agreed. Include:
+
+- **What we're solving** — restated in your own words, reflecting what you
+  verified in Step 2, not just the issue's title
+- **Approach chosen, and what it beat** — with the reasoning
+- **Steps** — ordered, each concrete enough to act on, naming the files involved
+- **Tradeoffs and risks** — what could go wrong, what is hard to undo
+- **Verification** — how we'll confirm it works. For anything user-visible this
+  means the real app via `/run-anisprinkles`, since unit tests here cover pure
+  algorithms and can't tell you a screen renders correctly
+- **Out of scope** — what we're deliberately not doing
+
+If the answers in Step 4 changed your thinking, say so and say how. The user
+should be able to see their input reflected rather than having to check.
+
+---
+
+## Step 6 — Cut the branch
+
+Only after approval. Branch off `main`, named `feature/<issue#>-<short-slug>`
+(e.g. `feature/112-diagnostic-log-export`) — that convention is the most useful
+of the several in this repo's history because it ties the branch back to the
+issue. For a batch that is genuinely one unit of work, use the lowest issue
+number and mention the others in the branch name or the eventual PR body.
+
+Confirm the branch name before creating it; it is annoying to rename later.
+
+Create the branch and stop there. Don't commit, don't push, and don't start
+implementing — per `AGENTS.md`, those are separate explicit asks. Hand back with
+a one-line summary of what was agreed and what the next step is.
+
+---
+
+## Handling several issues at once
+
+When given multiple numbers, work out whether they are one unit of work or
+separate threads before planning anything — the answer changes everything
+downstream.
+
+They are **one unit** when they share a root cause, when one is a precondition
+for another (#62 unblocks #52), or when doing them separately would mean touching
+the same code twice. Plan them together, one branch, and be explicit about the
+ordering between them.
+
+They are **separate** when they merely share a page or a label. Say so, and ask
+whether to take them one at a time or plan both now — planning several unrelated
+issues in one pass produces a plan too big to hold in your head, and the
+clarifying questions bleed together confusingly.
+
+Either way, run Step 2 on each issue independently. Staleness is per-issue, and a
+batch is exactly where a closed or superseded one hides.
+
+---
+
+## Related skills
+
+- `/project-architecture` — DI table, page patterns, navigation, performance defaults
+- `/ani-debug` — on-device diagnostics, when the issue is a bug observed on a device
+- `/run-anisprinkles` — build, launch, and drive the app to reproduce a bug or verify a fix
+- `/ani-review` — the review pass to run after the implementation lands

--- a/.claude/skills/ani-kickoff/SKILL.md
+++ b/.claude/skills/ani-kickoff/SKILL.md
@@ -23,11 +23,15 @@ branch to build it on.
 
 ```bash
 gh issue view <N> --json number,title,state,body,labels,createdAt,updatedAt,closedAt,comments \
-  --template '#{{.number}} {{.title}} [{{.state}}] created={{.createdAt}} updated={{.updatedAt}} comments={{len .comments}}{{"\n"}}labels:{{range .labels}} {{.name}}{{end}}{{"\n"}}---{{"\n"}}{{.body}}'
+  --template '#{{.number}} {{.title}} [{{.state}}] created={{.createdAt}} updated={{.updatedAt}} closed={{.closedAt}}{{"\n"}}labels:{{range .labels}} {{.name}}{{end}}{{"\n"}}--- body ---{{"\n"}}{{.body}}{{range .comments}}{{"\n"}}--- comment by {{.author.login}} @ {{.createdAt}} ---{{"\n"}}{{.body}}{{end}}'
 ```
 
-Read the comments too — they often contain the decision that the body never got
-updated to reflect.
+That template deliberately renders every comment body, not just a count. Comments
+are where the decision that nobody folded back into the body tends to live, and
+they are disproportionately likely to be the thing that settles an issue: #56's
+entire status is a one-line comment saying it was filed by mistake, and #52's
+open design question exists only in its comment thread. A count tells you
+nothing.
 
 Issue bodies in this repo vary wildly in density, and that difference should
 change how you work:

--- a/.claude/skills/run-anisprinkles/SKILL.md
+++ b/.claude/skills/run-anisprinkles/SKILL.md
@@ -1,0 +1,234 @@
+---
+name: run-anisprinkles
+description: "Build, install, launch, and drive the AniSprinkles MAUI Android app on an emulator — tap, type, scroll, screenshot, and read the on-screen text. Use when asked to run or start the app, take a screenshot, reproduce a UI bug, or confirm a change actually works on device rather than only in tests."
+allowed-tools: Bash(pwsh *) PowerShell Bash(adb *) Bash(dotnet *) Read Grep Glob
+---
+
+# Run AniSprinkles
+
+Android-only .NET MAUI app. There is no desktop target and no web surface — the
+only way to see a change is on an emulator or device.
+
+Everything below is driven by **`.claude/skills/run-anisprinkles/driver.ps1`**, a
+PowerShell harness that wraps `adb` + `uiautomator`. It resolves the correct
+Android SDK, boots the AVD, installs the APK, and gives you `tap` / `type` /
+`scroll-to` / `dump` / `shot` so you can drive the UI and read the screen as
+text without looking at a single pixel.
+
+Paths below are relative to the repo root.
+
+---
+
+## Prerequisites
+
+Already present on this machine; listed so you can check them if something breaks.
+
+- .NET 10 SDK (`dotnet --version` → `10.0.303`) with the `maui-android` workload
+- Android SDK at `C:\Program Files (x86)\Android\android-sdk`
+  (platform-tools 36.0.0, emulator 35.5.10, API 36 `google_apis_playstore` x86_64 image)
+- An AVD — the driver defaults to `pixel_9_-_api_36`
+
+Check all of it at once:
+
+```bash
+pwsh -NoProfile -File .claude/skills/run-anisprinkles/driver.ps1 env
+```
+
+---
+
+## Build
+
+Always build with `-p:CiBuild=true`. That swaps in `CIAuthService` /
+`CIAniListClient` / `CIAiringNotificationService` (`src/Services/CI/`), so the app
+launches **already signed in** against hardcoded fixtures: no OAuth round-trip, no
+real AniList traffic, no rate-limit budget spent, and a deterministic list every
+run. A plain Debug build drops you on the signed-out screen and there is no
+scriptable way past `WebAuthenticator`.
+
+```bash
+pwsh -NoProfile -File .claude/skills/run-anisprinkles/driver.ps1 build
+```
+
+Takes **~6 minutes** from cold (`Time Elapsed 00:05:53`) and produces a ~97 MB APK
+at `src/bin/Debug/net10.0-android/com.RainbowSprinkles.AniSprinkles-Signed.apk`.
+Skip it if you have not touched `src/` since the last build.
+
+---
+
+## Run (agent path)
+
+One-shot — boots the emulator if needed, installs, launches:
+
+```bash
+pwsh -NoProfile -File .claude/skills/run-anisprinkles/driver.ps1 up
+```
+
+Then drive it. Every command is `driver.ps1 <command> [args]`:
+
+| | |
+|---|---|
+| `env` | resolved SDK / adb / APK / device state |
+| `boot [avd]` | start emulator, block until `sys.boot_completed`, kill animations |
+| `build` / `install` / `launch` | individually |
+| `resume` | re-foreground the app **without** restarting it (warm, ~3s) |
+| `stop` / `kill-emu` | force-stop the app / shut the AVD down |
+| `shot <name>` | PNG → `tmp/driver-screens/<name>.png` |
+| `dump [filter]` | **print every visible text/content-desc node** — read the screen as text |
+| `xml [path]` | raw uiautomator XML when `dump` is not enough |
+| `tap <text>` | tap a node by exact visible text |
+| `tap-prefix <text>` | tap by text prefix — needed for `"View All ›"` (multibyte chevron) |
+| `tap-desc <desc>` | tap by content-desc — the icon buttons (`Toggle favorite`, `Open studio X`) |
+| `longpress <text>` | opens the quick-actions sheet on any anime card |
+| `type <text>` / `clear [n]` | type into / empty the focused field |
+| `key <KEYCODE>` / `back` | `KEYCODE_` is prefixed for you |
+| `swipe up\|down\|left\|right` | one content-area swipe |
+| `scroll-to <text>` | swipe up until `<text>` is on screen (max 10) |
+| `wait-for <text> [secs]` | poll until `<text>` appears (default 30s) |
+| `flyout` / `goto <page>` | open the drawer / open the drawer and pick `My Anime`\|`Discover`\|`Settings` |
+| `search` | tap the Discover toolbar search icon (see Gotchas) |
+| `logcat [n]` / `applog` | app-PID logcat tail / the on-device rotating file log |
+
+`driver.ps1 help` prints the same list.
+
+**The loop that works:** `dump` to see what is on screen → `tap`/`tap-desc` the
+text you saw → `wait-for` the text you expect next → `shot` → `dump` again.
+Never `shot` straight after a `tap` that navigates (see Gotchas).
+
+### Worked example — verify the favorite toggle (this branch's feature)
+
+Every line below was run against the emulator; the output is verbatim.
+
+```bash
+pwsh -NoProfile -File .claude/skills/run-anisprinkles/driver.ps1 up
+pwsh -NoProfile -File .claude/skills/run-anisprinkles/driver.ps1 wait-for "ONE PIECE" 60
+pwsh -NoProfile -File .claude/skills/run-anisprinkles/driver.ps1 tap "ONE PIECE"
+pwsh -NoProfile -File .claude/skills/run-anisprinkles/driver.ps1 wait-for "Toggle favorite" 45
+pwsh -NoProfile -File .claude/skills/run-anisprinkles/driver.ps1 shot before
+pwsh -NoProfile -File .claude/skills/run-anisprinkles/driver.ps1 tap-desc "Toggle favorite"
+pwsh -NoProfile -File .claude/skills/run-anisprinkles/driver.ps1 shot after
+```
+
+```
+[driver] tap text='ONE PIECE' at (286,1000)
+[driver] 'Toggle favorite' after 2s
+[driver] tap content-desc='Toggle favorite' at (960,379)
+[driver] C:\...\tmp\driver-screens\after.png (1192 KB)
+```
+
+Then `Read` the two PNGs: heart outline → filled, Favourites `90,457` → `90,458`.
+
+### Fixture data you can drive against
+
+`CIAniListClient` serves a fixed set, so these strings are always tappable:
+
+- **My Anime**: `ONE PIECE`, `Shingeki no Kyojin`, `Jujutsu Kaisen`, `HUNTER×HUNTER (2011)`;
+  section headers `Watching` / `Planning` / `Completed`
+- **Media details** (ONE PIECE): `Monkey D. Luffy`, `Roronoa Zoro`, `Nami`,
+  studios `Toei Animation` / `Madhouse` / `Studio Pierrot`; content-descs
+  `Toggle favorite` and `Open studio Toei Animation`
+- **Discover**: `Currently Airing`, `Trending Now`, `Top Anime`, `View All ›`
+- **Search** filters that same fixture list client-side — `one` matches `ONE PIECE`;
+  anything else (e.g. `cowboy bebop`) correctly renders `No anime found`. That is
+  the stub, not a bug.
+
+---
+
+## Run (human path)
+
+Deploy from Visual Studio / `dotnet build -t:Run`, or just `driver.ps1 up` and
+look at the emulator window. Useful for OAuth-dependent work — the CI stubs are
+the only scriptable way past sign-in, so testing the *real* auth flow means
+building without `-p:CiBuild=true` and tapping through the browser yourself.
+
+---
+
+## Test
+
+```bash
+dotnet test tests/AniSprinkles.UnitTests/AniSprinkles.UnitTests.csproj -c Debug
+```
+
+Pure-algorithm + XAML-well-formedness tests only; no device needed. They do **not**
+cover PageModels or any UI, so a green run says nothing about whether the app
+works — that is what the driver above is for.
+
+---
+
+## Gotchas
+
+- **Two Android SDKs are installed and PATH points at the wrong one.**
+  `%LOCALAPPDATA%\Android\Sdk` (adb 34, no API 36 system image) shadows
+  `C:\Program Files (x86)\Android\android-sdk` (adb 36, has the images). Launching
+  the emulator from the PATH copy dies with `PANIC: Cannot find AVD system path`,
+  and mixing the two adb binaries makes the daemon restart mid-session. The driver
+  picks the root that actually has `system-images/` — **don't call bare `adb`**,
+  go through the driver or use the full `Program Files (x86)` path.
+
+- **Git Bash rewrites device paths.** `adb shell df /data` from Bash becomes
+  `df 'C:/Program Files/Git/data'`. Prefix with `MSYS_NO_PATHCONV=1`, or just use
+  the driver (PowerShell, unaffected). This silently returns empty output rather
+  than erroring, which is how it burns you.
+
+- **Never pipe `adb exec-out screencap -p` into a PowerShell redirect** — the PNG
+  comes out corrupt (text encoding + CRLF). `driver.ps1 shot` writes on-device and
+  `adb pull`s it back, which is byte-exact.
+
+- **`adb shell` mangles output you intend to parse** (LF→CRLF). The driver uses
+  `exec-out` everywhere it reads.
+
+- **`shot` immediately after a navigating `tap` captures the loading spinner.**
+  Shell transitions plus the details fetch run well past the driver's 1.2s
+  post-tap settle. Always `wait-for "<text you expect>"` between them. I caught
+  `Loading discover...` and a stale details page this way twice.
+
+- **`DiscoverPageModel` is a singleton, so the search bar keeps its text forever** —
+  navigating away, backing out of the app entirely, and coming back still shows the
+  old query and its results, not the section rows. If `wait-for "Trending Now"`
+  times out on Discover, the search bar is open: `driver.ps1 search` toggles it
+  shut and the sections come back.
+
+- **MAUI Shell toolbar items are invisible to uiautomator.** Only the hamburger has
+  a content-desc; the search / sort / layout icons have no node at all, so there is
+  nothing to `tap-desc`. `driver.ps1 search` works around it by mirroring the
+  hamburger's x across the screen width (`1080 - 74 = 1006`), which is
+  resolution-independent.
+
+- **`back` at a flyout root exits the app silently** — no confirm dialog, you just
+  land on the launcher and every subsequent `tap` fails with a confusing
+  "No node with text=...". `driver.ps1 resume` gets you back in ~3s. Prefer `goto`
+  over `back` for switching pages.
+
+- **`View All ›` carries a multibyte chevron in its text node.** Exact-match `tap`
+  never finds it; use `tap-prefix "View All"`.
+
+- **`KEYCODE_CTRL_A` is not select-all on Android.** `driver.ps1 clear` spams
+  `KEYCODE_DEL` instead.
+
+- **The debug APK is ~97 MB and installs land on `INSUFFICIENT_STORAGE`** once the
+  AVD's `/data` gets tight (mine had 570 MB free and still failed). `driver.ps1
+  install` detects it, uninstalls the old copy, and retries. Note that `adb install`
+  prints `Failure [...]` and can still exit 0 — the driver parses the output text,
+  so don't trust a bare `adb install`'s exit code.
+
+- **Cold launch is ~19s** (`TotalTime: 18697`) — Debug MAUI with embedded
+  assemblies. `driver.ps1 launch` polls for the process, so it returns before the
+  UI has content. `wait-for` is what tells you the page actually rendered.
+
+---
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| `PANIC: Cannot find AVD system path. Please define ANDROID_SDK_ROOT` | You launched the PATH emulator. Use `driver.ps1 boot`. |
+| `adb server version doesn't match this client` | Two adb versions fighting. `adb kill-server`, then let the driver restart the right one. |
+| `INSUFFICIENT_STORAGE: Failed to override installation location` | `driver.ps1 install` handles it; if it still fails, wipe the AVD from Device Manager. |
+| `UI dump was empty — is the app foregrounded?` | The app is backgrounded or crashed. `driver.ps1 resume`, then `driver.ps1 logcat`. |
+| `No node with text='X'` right after it worked | You probably backed out to the launcher. `driver.ps1 dump` to confirm, then `resume`. |
+| `'X' never appeared within Ns` on Discover | Search bar is still open with an old query — `driver.ps1 search`. |
+| `df 'C:/Program Files/Git/data': No such file` | Git Bash path mangling — `MSYS_NO_PATHCONV=1`. |
+| App runs but shows the signed-out screen | You built without `-p:CiBuild=true`. Rebuild with `driver.ps1 build`. |
+
+For deeper on-device diagnostics (ANR / jank / Glide cascades / NAVTRACE timings),
+switch to **`/ani-debug`** — it has the full log-collection and interpretation
+workflow. `driver.ps1 logcat` and `driver.ps1 applog` are the quick versions.

--- a/.claude/skills/run-anisprinkles/SKILL.md
+++ b/.claude/skills/run-anisprinkles/SKILL.md
@@ -94,7 +94,7 @@ Then drive it. Every command is `driver.ps1 <command> [args]`:
 text you saw → `wait-for` the text you expect next → `shot` → `dump` again.
 Never `shot` straight after a `tap` that navigates (see Gotchas).
 
-### Worked example — verify the favorite toggle (this branch's feature)
+### Worked example — a full round trip
 
 Every line below was run against the emulator; the output is verbatim.
 
@@ -210,6 +210,25 @@ works — that is what the driver above is for.
   prints `Failure [...]` and can still exit 0 — the driver parses the output text,
   so don't trust a bare `adb install`'s exit code.
 
+- **With two devices attached, pick one explicitly.** Every driver command targets
+  a single device via `adb -s`. With one device it resolves automatically; with
+  more than one it stops and lists them rather than letting `adb` fail with a bare
+  "more than one device/emulator" partway through a flow. Set `ANDROID_SERIAL` to
+  choose:
+
+  ```bash
+  ANDROID_SERIAL=emulator-5554 pwsh -NoProfile -File .claude/skills/run-anisprinkles/driver.ps1 shot home
+  ```
+
+  `driver.ps1 env` lists every attached device with its AVD name and shows which
+  one is currently resolved.
+
+- **`boot` reuses an emulator only if it is the AVD you asked for.** A different
+  AVD already running does not count, so `boot tablet_h-dpi_13_5in_-_api_36_0`
+  starts that tablet even with a Pixel online. It also waits for
+  `sys.boot_completed` on reuse, because `device` state only means adb can talk to
+  the emulator — not that Android finished booting.
+
 - **Cold launch is ~19s** (`TotalTime: 18697`) — Debug MAUI with embedded
   assemblies. `driver.ps1 launch` polls for the process, so it returns before the
   UI has content. `wait-for` is what tells you the page actually rendered.
@@ -226,6 +245,8 @@ works — that is what the driver above is for.
 | `UI dump was empty — is the app foregrounded?` | The app is backgrounded or crashed. `driver.ps1 resume`, then `driver.ps1 logcat`. |
 | `No node with text='X'` right after it worked | You probably backed out to the launcher. `driver.ps1 dump` to confirm, then `resume`. |
 | `'X' never appeared within Ns` on Discover | Search bar is still open with an old query — `driver.ps1 search`. |
+| `More than one device attached — set ANDROID_SERIAL to choose` | Two emulators/devices online. Pick one with `ANDROID_SERIAL=<serial>`, or shut the other down. `driver.ps1 env` lists them. |
+| `sys.boot_completed never reached 1 after 180s` | The emulator attached to adb but never finished booting. Check the emulator window; a wipe-data from Device Manager usually clears it. |
 | `df 'C:/Program Files/Git/data': No such file` | Git Bash path mangling — `MSYS_NO_PATHCONV=1`. |
 | App runs but shows the signed-out screen | You built without `-p:CiBuild=true`. Rebuild with `driver.ps1 build`. |
 

--- a/.claude/skills/run-anisprinkles/driver.ps1
+++ b/.claude/skills/run-anisprinkles/driver.ps1
@@ -61,13 +61,68 @@ $Sdk = Resolve-Sdk
 $Adb = Join-Path $Sdk 'platform-tools\adb.exe'
 $Emu = Join-Path $Sdk 'emulator\emulator.exe'
 
-function Adb { & $Adb @args }
+# ---------------------------------------------------------------- device target
+# Every adb call routes through Adb/AdbOut so a single `-s <serial>` is applied
+# consistently. Without it a second attached device (a phone plugged in, a
+# leftover AVD) makes every command die with "more than one device/emulator",
+# which reads like a driver bug rather than an ambiguity.
+$script:Serial = $env:ANDROID_SERIAL
+
+function Adb {
+    if ($script:Serial) { & $Adb -s $script:Serial @args } else { & $Adb @args }
+}
 
 # `adb shell` translates LF -> CRLF and mangles binary. `exec-out` does not.
 # Always use this for anything you intend to parse or write to a file.
-function AdbOut { & $Adb exec-out @args }
+function AdbOut {
+    if ($script:Serial) { & $Adb -s $script:Serial exec-out @args } else { & $Adb exec-out @args }
+}
 
 function Say($msg) { Write-Host "[driver] $msg" }
+
+function Get-AttachedDevices {
+    # Only devices in `device` state — `offline` and `unauthorized` cannot be driven.
+    @(& $Adb devices | ForEach-Object { if ($_ -match '^(\S+)\s+device\s*$') { $Matches[1] } })
+}
+
+function Get-AvdName {
+    param([string]$DeviceSerial)
+    # `adb -s <serial> emu avd name` prints the AVD name, then a line reading OK.
+    # Physical devices have no console and just error, so treat failure as "no AVD".
+    $out = & $Adb -s $DeviceSerial emu avd name 2>$null
+    if (-not $out) { return $null }
+    ($out | Where-Object { $_ -and $_.Trim() -and $_.Trim() -ne 'OK' } | Select-Object -First 1).Trim()
+}
+
+function Resolve-Target {
+    # Pick the device every later command will talk to. Explicit ANDROID_SERIAL wins;
+    # otherwise a lone device is unambiguous, and anything else needs the user to say.
+    param([switch]$Required)
+    if ($script:Serial) { return $script:Serial }
+    # @() is required at the CALL site, not just inside the function: PowerShell
+    # unrolls a one-element array on return, so without it $devices is a bare
+    # string and $devices[0] silently yields its first character.
+    $devices = @(Get-AttachedDevices)
+    if ($devices.Count -eq 1) { $script:Serial = $devices[0]; return $script:Serial }
+    if ($devices.Count -gt 1) {
+        $detail = ($devices | ForEach-Object { "  $_  (avd: $(Get-AvdName $_))" }) -join "`n"
+        throw "More than one device attached — set ANDROID_SERIAL to choose:`n$detail"
+    }
+    if ($Required) { throw 'No device attached. Run: driver.ps1 boot' }
+    return $null
+}
+
+function Wait-BootCompleted {
+    param([int]$Seconds = 180)
+    for ($i = 0; $i -lt $Seconds; $i++) {
+        $b = (AdbOut getprop sys.boot_completed) -join '' -replace '\s', ''
+        if ($b -eq '1') { Say "boot complete after ${i}s"; return }
+        Start-Sleep -Seconds 1
+    }
+    # Previously this loop just fell through, so a device that never finished
+    # booting was reported as ready and the next command failed confusingly.
+    throw "sys.boot_completed never reached 1 after ${Seconds}s"
+}
 
 # ------------------------------------------------------------------- UI probing
 
@@ -176,30 +231,47 @@ function Cmd-Env {
     Say "repo     : $RepoRoot"
     Say "apk      : $Apk  (exists: $(Test-Path $Apk))"
     Say 'devices  :'
-    Adb devices
+    foreach ($d in Get-AttachedDevices) { Say "  $d  (avd: $(Get-AvdName $d))" }
+    # Deliberately non-fatal: `env` is what you run to diagnose "no device", so it
+    # must report the situation rather than throw on it.
+    $t = try { Resolve-Target } catch { $null }
+    Say "target   : $(if ($t) { $t } else { '(none resolved)' })"
 }
 
 function Cmd-Boot {
     param([string]$Avd = 'pixel_9_-_api_36')
 
-    $running = (Adb devices) -match 'emulator-\d+\s+device'
-    if ($running) { Say 'emulator already online'; return }
+    # Reuse an emulator only if it is the AVD that was actually asked for. Matching
+    # on "any emulator is online" meant `boot <other-avd>` silently did nothing and
+    # every subsequent command drove the wrong device.
+    $existing = Get-AttachedDevices | Where-Object { (Get-AvdName $_) -eq $Avd } | Select-Object -First 1
+    if ($existing) {
+        $script:Serial = $existing
+        Say "AVD $Avd already online at $existing"
+    } else {
+        $others = @(Get-AttachedDevices)
+        if ($others) { Say "note: $($others.Count) other device(s) attached; targeting $Avd once it boots" }
 
-    Say "starting AVD $Avd"
-    # ANDROID_SDK_ROOT must match the emulator we picked, or it re-searches PATH's SDK.
-    $env:ANDROID_SDK_ROOT = $Sdk
-    $env:ANDROID_HOME = $Sdk
-    Start-Process -FilePath $Emu `
-        -ArgumentList @('-avd', $Avd, '-no-boot-anim', '-no-snapshot-save') `
-        -WindowStyle Minimized
+        Say "starting AVD $Avd"
+        # ANDROID_SDK_ROOT must match the emulator we picked, or it re-searches PATH's SDK.
+        $env:ANDROID_SDK_ROOT = $Sdk
+        $env:ANDROID_HOME = $Sdk
+        Start-Process -FilePath $Emu `
+            -ArgumentList @('-avd', $Avd, '-no-boot-anim', '-no-snapshot-save') `
+            -WindowStyle Minimized
 
-    Adb wait-for-device
-    Say 'device attached, waiting for sys.boot_completed'
-    for ($i = 0; $i -lt 180; $i++) {
-        $b = (AdbOut getprop sys.boot_completed) -join '' -replace '\s', ''
-        if ($b -eq '1') { Say "boot complete after ${i}s"; break }
-        Start-Sleep -Seconds 1
+        Say 'waiting for the new emulator to attach'
+        for ($i = 0; $i -lt 180; $i++) {
+            $match = Get-AttachedDevices | Where-Object { (Get-AvdName $_) -eq $Avd } | Select-Object -First 1
+            if ($match) { $script:Serial = $match; Say "attached at $match after ${i}s"; break }
+            Start-Sleep -Seconds 1
+        }
+        if (-not $script:Serial) { throw "AVD $Avd never attached to adb" }
     }
+
+    # Run this even when reusing a device: `device` state only means adb can talk
+    # to it, not that Android has finished booting.
+    Wait-BootCompleted
     Adb shell wm dismiss-keyguard *> $null
     Adb shell settings put global window_animation_scale 0 *> $null
     Adb shell settings put global transition_animation_scale 0 *> $null
@@ -381,7 +453,17 @@ function Cmd-AppLog {
 # --------------------------------------------------------------- dispatch
 
 $a = @($Args)
-switch ($Command.ToLowerInvariant()) {
+$cmd = $Command.ToLowerInvariant()
+
+# Anything that talks to a device needs an unambiguous target resolved up front,
+# so ambiguity surfaces as "set ANDROID_SERIAL to choose" rather than adb's bare
+# "more than one device/emulator" halfway through a flow. `boot` and `up` pick
+# their own target from the requested AVD; the rest need one already attached.
+if ($cmd -notin @('help', 'env', 'build', 'boot', 'up')) {
+    Resolve-Target -Required | Out-Null
+}
+
+switch ($cmd) {
     'help'       { Cmd-Help }
     'env'        { Cmd-Env }
     'boot'       { if ($a[0]) { Cmd-Boot $a[0] } else { Cmd-Boot } }

--- a/.claude/skills/run-anisprinkles/driver.ps1
+++ b/.claude/skills/run-anisprinkles/driver.ps1
@@ -1,0 +1,422 @@
+<#
+.SYNOPSIS
+  Build / launch / drive AniSprinkles on an Android emulator from the command line.
+
+.DESCRIPTION
+  Agent-facing harness for the MAUI Android app. Every command is a subcommand:
+
+      pwsh .claude/skills/run-anisprinkles/driver.ps1 <command> [args]
+
+  Run `driver.ps1 help` for the full command list.
+
+  Written for Windows + PowerShell 7. It pins itself to the Android SDK that
+  actually has the AVD system images (see Resolve-Sdk) so it does not pick up a
+  stale adb from PATH.
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Position = 0)]
+    [string]$Command = 'help',
+
+    [Parameter(Position = 1, ValueFromRemainingArguments = $true)]
+    [string[]]$Args
+)
+
+$ErrorActionPreference = 'Stop'
+
+$Package  = 'com.RainbowSprinkles.AniSprinkles'
+$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..\..')).Path
+$ShotDir  = Join-Path $RepoRoot 'tmp\driver-screens'
+$Apk      = Join-Path $RepoRoot 'src\bin\Debug\net10.0-android\com.RainbowSprinkles.AniSprinkles-Signed.apk'
+
+# ---------------------------------------------------------------- SDK plumbing
+
+function Resolve-Sdk {
+    # This machine has TWO Android SDK roots:
+    #   C:\Program Files (x86)\Android\android-sdk   (VS/Xamarin — has the API 36 images, adb 36)
+    #   %LOCALAPPDATA%\Android\Sdk                   (partial Android Studio — adb 34, no API 36 image)
+    # PATH points at the second one, whose emulator PANICs with
+    # "Cannot find AVD system path". Pick the root that actually has system images.
+    $candidates = @()
+    if ($env:ANDROID_SDK_ROOT) { $candidates += $env:ANDROID_SDK_ROOT }
+    if ($env:ANDROID_HOME)     { $candidates += $env:ANDROID_HOME }
+    $candidates += "${env:ProgramFiles(x86)}\Android\android-sdk"
+    $candidates += "$env:LOCALAPPDATA\Android\Sdk"
+
+    foreach ($c in $candidates) {
+        if (-not $c) { continue }
+        $adb = Join-Path $c 'platform-tools\adb.exe'
+        $emu = Join-Path $c 'emulator\emulator.exe'
+        $img = Join-Path $c 'system-images'
+        if ((Test-Path $adb) -and (Test-Path $emu) -and
+            (Test-Path $img) -and (Get-ChildItem $img -Directory -EA SilentlyContinue)) {
+            return $c
+        }
+    }
+    throw "No Android SDK root with emulator + system-images found. Tried:`n  $($candidates -join "`n  ")"
+}
+
+$Sdk = Resolve-Sdk
+$Adb = Join-Path $Sdk 'platform-tools\adb.exe'
+$Emu = Join-Path $Sdk 'emulator\emulator.exe'
+
+function Adb { & $Adb @args }
+
+# `adb shell` translates LF -> CRLF and mangles binary. `exec-out` does not.
+# Always use this for anything you intend to parse or write to a file.
+function AdbOut { & $Adb exec-out @args }
+
+function Say($msg) { Write-Host "[driver] $msg" }
+
+# ------------------------------------------------------------------- UI probing
+
+function Get-UiDump {
+    # uiautomator writes to the device, then we stream it back with exec-out.
+    # Do NOT try `uiautomator dump /dev/tty` — it interleaves the tool's own
+    # "UI hierarchy dumped to:" status line into the XML.
+    Adb shell rm -f /sdcard/ui.xml *> $null
+    Adb shell uiautomator dump /sdcard/ui.xml *> $null
+    $xml = AdbOut cat /sdcard/ui.xml
+    if (-not $xml) { throw 'UI dump was empty — is the app foregrounded?' }
+    return ($xml -join '')
+}
+
+function Find-Bounds {
+    param([string]$Xml, [string]$Attr, [string]$Value, [switch]$Prefix)
+
+    # Split on '>' so each node is its own line; otherwise a greedy match can
+    # pick up the bounds of a LATER node than the one whose text matched.
+    $nodes = $Xml -split '>'
+    $esc = [regex]::Escape($Value)
+    $pattern = if ($Prefix) { "$Attr=`"$esc[^`"]*`"" } else { "$Attr=`"$esc`"" }
+
+    foreach ($n in $nodes) {
+        if ($n -match $pattern -and $n -match 'bounds="\[(\d+),(\d+)\]\[(\d+),(\d+)\]"') {
+            return [pscustomobject]@{
+                L = [int]$Matches[1]; T = [int]$Matches[2]
+                R = [int]$Matches[3]; B = [int]$Matches[4]
+                CX = [int](([int]$Matches[1] + [int]$Matches[3]) / 2)
+                CY = [int](([int]$Matches[2] + [int]$Matches[4]) / 2)
+            }
+        }
+    }
+    return $null
+}
+
+function Tap-By {
+    param([string]$Attr, [string]$Value, [switch]$Long, [switch]$Prefix)
+    # An empty value would happily match the app's many empty text="" nodes and tap
+    # something arbitrary — fail loudly instead.
+    if (-not $Value) { throw "no $Attr given, e.g. driver.ps1 tap `"ONE PIECE`"" }
+    $b = Find-Bounds -Xml (Get-UiDump) -Attr $Attr -Value $Value -Prefix:$Prefix
+    if (-not $b) { throw "No node with $Attr='$Value'" }
+    if ($Long) {
+        Say "long-press $Attr='$Value' at ($($b.CX),$($b.CY))"
+        Adb shell input swipe $b.CX $b.CY $b.CX $b.CY 800 *> $null
+    } else {
+        Say "tap $Attr='$Value' at ($($b.CX),$($b.CY))"
+        Adb shell input tap $b.CX $b.CY *> $null
+    }
+    Start-Sleep -Milliseconds 1200
+}
+
+function Get-ScreenSize {
+    $s = (AdbOut wm size) -join ''
+    if ($s -match '(\d+)x(\d+)') { return @([int]$Matches[1], [int]$Matches[2]) }
+    throw "Could not read screen size from '$s'"
+}
+
+# ---------------------------------------------------------------- commands
+
+function Cmd-Help {
+@"
+AniSprinkles driver — pwsh .claude/skills/run-anisprinkles/driver.ps1 <command>
+
+  env                       Show resolved SDK / adb / device state
+  boot [avd]                Start the emulator and block until boot completes
+                            (default AVD: pixel_9_-_api_36)
+  build                     dotnet build -p:CiBuild=true (stub auth + stub API data)
+  install                   adb install -r -d the signed debug APK
+  launch                    Force-restart the app (cold, ~20s) and wait for its process
+  resume                    Bring the app back to the foreground without restarting
+                            (use after a stray `back` drops you to the launcher)
+  up [avd]                  boot + install + launch
+  stop                      Force-stop the app
+  kill-emu                  Shut the emulator down
+
+  shot <name>               Screenshot -> tmp/driver-screens/<name>.png
+  dump [filter]             Print visible text/content-desc nodes (optionally grepped)
+  xml [path]                Save the raw uiautomator XML (default tmp/driver-screens/ui.xml)
+
+  tap <text>                Tap a node by exact visible text
+  tap-prefix <text>         Tap a node whose text STARTS WITH <text>   (e.g. "View All")
+  tap-desc <desc>           Tap a node by content-desc (icon buttons)
+  longpress <text>          Long-press a node by visible text (opens quick-actions)
+  type <text>               Type into the focused field
+  clear [n]                 Delete n chars (default 60) from the focused field
+  key <KEYCODE>             e.g. BACK, ENTER, HOME
+  back                      KEYCODE_BACK
+  swipe up|down|left|right  One content-area swipe
+  scroll-to <text>          Swipe up until <text> appears (max 10)
+  wait-for <text> [secs]    Poll the UI until <text> appears (default 30s)
+  flyout                    Open the Shell navigation drawer
+  search                    Tap the Discover toolbar search icon (see Gotchas)
+  goto <My Anime|Discover|Settings>   Open the drawer and pick a page
+
+  logcat [lines]            App-PID logcat tail (default 200)
+  applog                    Pull the on-device rotating file log
+"@ | Write-Host
+}
+
+function Cmd-Env {
+    Say "SDK      : $Sdk"
+    Say "adb      : $Adb  ($(((& $Adb version) | Select-Object -Index 1)))"
+    Say "emulator : $Emu"
+    Say "repo     : $RepoRoot"
+    Say "apk      : $Apk  (exists: $(Test-Path $Apk))"
+    Say 'devices  :'
+    Adb devices
+}
+
+function Cmd-Boot {
+    param([string]$Avd = 'pixel_9_-_api_36')
+
+    $running = (Adb devices) -match 'emulator-\d+\s+device'
+    if ($running) { Say 'emulator already online'; return }
+
+    Say "starting AVD $Avd"
+    # ANDROID_SDK_ROOT must match the emulator we picked, or it re-searches PATH's SDK.
+    $env:ANDROID_SDK_ROOT = $Sdk
+    $env:ANDROID_HOME = $Sdk
+    Start-Process -FilePath $Emu `
+        -ArgumentList @('-avd', $Avd, '-no-boot-anim', '-no-snapshot-save') `
+        -WindowStyle Minimized
+
+    Adb wait-for-device
+    Say 'device attached, waiting for sys.boot_completed'
+    for ($i = 0; $i -lt 180; $i++) {
+        $b = (AdbOut getprop sys.boot_completed) -join '' -replace '\s', ''
+        if ($b -eq '1') { Say "boot complete after ${i}s"; break }
+        Start-Sleep -Seconds 1
+    }
+    Adb shell wm dismiss-keyguard *> $null
+    Adb shell settings put global window_animation_scale 0 *> $null
+    Adb shell settings put global transition_animation_scale 0 *> $null
+    Adb shell settings put global animator_duration_scale 0 *> $null
+    Say 'ready (animations disabled)'
+}
+
+function Cmd-Build {
+    # CiBuild=true swaps in CIAuthService / CIAniListClient / CIAiringNotificationService,
+    # so the app launches already "signed in" with fixture data. No OAuth, no AniList calls,
+    # no rate-limit budget spent. EmbedAssembliesIntoApk makes the APK self-contained.
+    Say 'dotnet build (Debug, CI stubs)'
+    Push-Location $RepoRoot
+    try {
+        & dotnet build src/AniSprinkles.csproj -c Debug -f net10.0-android `
+            -p:EmbedAssembliesIntoApk=true -p:CiBuild=true
+        if ($LASTEXITCODE -ne 0) { throw "build failed ($LASTEXITCODE)" }
+    } finally { Pop-Location }
+    Say "apk: $Apk"
+}
+
+function Cmd-Install {
+    if (-not (Test-Path $Apk)) { throw "APK missing — run: driver.ps1 build" }
+    $mb = [math]::Round((Get-Item $Apk).Length / 1MB)
+    Say "installing $(Split-Path $Apk -Leaf) (${mb} MB)"
+
+    # NOTE: `adb install` prints "Failure [...]" to STDOUT and STILL exits 0 in some
+    # adb builds, and a stale build of the package left installed would make a
+    # naive `pm list packages` check pass. Parse the output text instead.
+    $out = (& $Adb install -r -d $Apk 2>&1) -join "`n"
+    Write-Host $out
+
+    if ($out -match 'INSUFFICIENT_STORAGE') {
+        # The CI-stub debug APK is ~100 MB (EmbedAssembliesIntoApk + debug symbols),
+        # and Android wants several times that free during install. Dropping the old
+        # copy first is usually enough.
+        Say 'insufficient storage — uninstalling old copy and retrying'
+        & $Adb uninstall $Package *> $null
+        $out = (& $Adb install $Apk 2>&1) -join "`n"
+        Write-Host $out
+    }
+
+    if ($out -notmatch 'Success') {
+        throw "install failed. Free space on the AVD:`n$((AdbOut df /data) -join "`n")"
+    }
+    Say 'installed'
+}
+
+function Cmd-Launch {
+    param([switch]$Resume)
+    Adb shell wm dismiss-keyguard *> $null
+    # Resolve the launcher activity instead of hardcoding it: MAUI generates a
+    # crc64-suffixed class name that changes if the namespace/assembly is renamed.
+    $activity = ((AdbOut cmd package resolve-activity --brief -c android.intent.category.LAUNCHER $Package) |
+                 Where-Object { $_ -match '/' } | Select-Object -Last 1).Trim()
+    if (-not $activity) { throw "could not resolve launcher activity for $Package" }
+    Say "am start $activity$(if ($Resume) { ' (warm)' })"
+    if ($Resume) { Adb shell am start -W -n $activity }
+    else         { Adb shell am start -W -S -n $activity }
+    for ($i = 0; $i -lt 40; $i++) {
+        if ((AdbOut pidof $Package) -join '' -match '\d') { Say "app up after ${i}s"; return }
+        Start-Sleep -Seconds 1
+    }
+    throw 'app process never appeared — check: driver.ps1 logcat'
+}
+
+function Cmd-Shot {
+    param([string]$Name = 'shot')
+    New-Item -ItemType Directory -Force -Path $ShotDir *> $null
+    $out = Join-Path $ShotDir "$Name.png"
+    # Capture on-device then pull. Piping `exec-out screencap -p` into a PowerShell
+    # redirect corrupts the PNG (text encoding + CRLF); `adb pull` is byte-exact.
+    Adb shell screencap -p /sdcard/shot.png *> $null
+    Adb pull /sdcard/shot.png $out *> $null
+    if (-not (Test-Path $out)) { throw 'screencap/pull produced no file' }
+    Say "$out ($([math]::Round((Get-Item $out).Length / 1KB)) KB)"
+    return $out
+}
+
+function Cmd-Dump {
+    param([string]$Filter)
+    $xml = Get-UiDump
+    $lines = foreach ($n in ($xml -split '>')) {
+        $t = if ($n -match 'text="([^"]*)"') { $Matches[1] } else { '' }
+        $d = if ($n -match 'content-desc="([^"]*)"') { $Matches[1] } else { '' }
+        if ($t -or $d) {
+            $bits = @()
+            if ($t) { $bits += "text=`"$t`"" }
+            if ($d) { $bits += "desc=`"$d`"" }
+            $bits -join '  '
+        }
+    }
+    $lines = $lines | Select-Object -Unique
+    if ($Filter) { $lines = $lines | Where-Object { $_ -like "*$Filter*" } }
+    $lines | Write-Host
+}
+
+function Cmd-Xml {
+    param([string]$Path)
+    New-Item -ItemType Directory -Force -Path $ShotDir *> $null
+    if (-not $Path) { $Path = Join-Path $ShotDir 'ui.xml' }
+    Get-UiDump | Set-Content -Path $Path -Encoding utf8
+    Say $Path
+}
+
+function Cmd-Swipe {
+    param([string]$Dir = 'up')
+    $w, $h = Get-ScreenSize
+    $cx = [int]($w / 2)
+    switch ($Dir) {
+        'up'    { Adb shell input swipe $cx ([int]($h * 0.75)) $cx ([int]($h * 0.28)) 300 *> $null }
+        'down'  { Adb shell input swipe $cx ([int]($h * 0.28)) $cx ([int]($h * 0.75)) 300 *> $null }
+        'left'  { Adb shell input swipe ([int]($w * 0.85)) ([int]($h / 2)) ([int]($w * 0.15)) ([int]($h / 2)) 300 *> $null }
+        'right' { Adb shell input swipe ([int]($w * 0.15)) ([int]($h / 2)) ([int]($w * 0.85)) ([int]($h / 2)) 300 *> $null }
+        default { throw "swipe direction must be up|down|left|right" }
+    }
+    Start-Sleep -Milliseconds 900
+}
+
+function Cmd-ScrollTo {
+    param([string]$Text, [int]$Max = 10)
+    for ($i = 0; $i -le $Max; $i++) {
+        if ((Get-UiDump) -match [regex]::Escape("text=`"$Text`"")) {
+            Say "found '$Text' after $i swipe(s)"; return
+        }
+        Cmd-Swipe up
+    }
+    throw "'$Text' not found after $Max swipes"
+}
+
+function Cmd-WaitFor {
+    param([string]$Text, [int]$Seconds = 30)
+    for ($i = 0; $i -lt $Seconds; $i++) {
+        try { if ((Get-UiDump) -match [regex]::Escape($Text)) { Say "'$Text' after ${i}s"; return } } catch { }
+        Start-Sleep -Seconds 1
+    }
+    throw "'$Text' never appeared within ${Seconds}s"
+}
+
+function Cmd-Flyout {
+    # The hamburger is the only Shell toolbar item uiautomator exposes with a
+    # content-desc; the page's own toolbar icons are invisible to it (see Gotchas).
+    Tap-By -Attr 'content-desc' -Value 'Open navigation drawer'
+    Start-Sleep -Milliseconds 800
+}
+
+function Cmd-Goto {
+    param([string]$Page)
+    Cmd-Flyout
+    Tap-By -Attr 'text' -Value $Page
+    Start-Sleep -Seconds 2
+}
+
+function Cmd-Search {
+    # MAUI Shell's page-level ToolbarItems are NOT exposed to uiautomator — they have
+    # no text and no content-desc, so there is no node to find. The hamburger IS
+    # exposed, and the toolbar is horizontally symmetric, so the rightmost icon sits
+    # at (screenWidth - hamburgerCX, hamburgerCY). Resolution-independent.
+    $b = Find-Bounds -Xml (Get-UiDump) -Attr 'content-desc' -Value 'Open navigation drawer'
+    if (-not $b) { throw 'toolbar hamburger not found — is a flyout page foregrounded?' }
+    $w, $null = Get-ScreenSize
+    $x = $w - $b.CX
+    Say "tap toolbar search at ($x,$($b.CY)) [mirror of hamburger $($b.CX),$($b.CY) on width $w]"
+    Adb shell input tap $x $b.CY *> $null
+    Start-Sleep -Milliseconds 1200
+}
+
+function Cmd-Logcat {
+    param([int]$Lines = 200)
+    $pidText = ((AdbOut pidof $Package) -join '').Trim()
+    if (-not $pidText) { throw 'app is not running' }
+    AdbOut logcat -d --pid $pidText -t $Lines
+}
+
+function Cmd-AppLog {
+    AdbOut run-as $Package cat files/logs/anisprinkles.log
+}
+
+# --------------------------------------------------------------- dispatch
+
+$a = @($Args)
+switch ($Command.ToLowerInvariant()) {
+    'help'       { Cmd-Help }
+    'env'        { Cmd-Env }
+    'boot'       { if ($a[0]) { Cmd-Boot $a[0] } else { Cmd-Boot } }
+    'build'      { Cmd-Build }
+    'install'    { Cmd-Install }
+    'launch'     { Cmd-Launch }
+    'resume'     { Cmd-Launch -Resume }
+    'up'         { if ($a[0]) { Cmd-Boot $a[0] } else { Cmd-Boot }; Cmd-Install; Cmd-Launch }
+    'stop'       { Adb shell am force-stop $Package; Say 'stopped' }
+    'kill-emu'   { Adb emu kill; Say 'emulator killed' }
+    'shot'       { if ($a[0]) { Cmd-Shot $a[0] } else { Cmd-Shot } }
+    'dump'       { Cmd-Dump ($a -join ' ') }
+    'xml'        { Cmd-Xml ($a[0]) }
+    'tap'        { Tap-By -Attr 'text' -Value ($a -join ' ') }
+    'tap-prefix' { Tap-By -Attr 'text' -Value ($a -join ' ') -Prefix }
+    'tap-desc'   { Tap-By -Attr 'content-desc' -Value ($a -join ' ') }
+    'longpress'  { Tap-By -Attr 'text' -Value ($a -join ' ') -Long }
+    'type'       { Adb shell input text (($a -join ' ') -replace ' ', '%s'); Start-Sleep -Milliseconds 600 }
+    'clear'      { # KEYCODE_CTRL_A is not select-all on Android — spam DEL instead.
+                   $n = if ($a[0] -match '^\d+$') { [int]$a[0] } else { 60 }
+                   Adb shell input keyevent KEYCODE_MOVE_END *> $null
+                   Adb shell input keyevent (@('KEYCODE_DEL') * $n) *> $null
+                   Start-Sleep -Milliseconds 600 }
+    'key'        { if (-not $a[0]) { throw 'key needs a keycode, e.g. driver.ps1 key ENTER' }
+                   Adb shell input keyevent "KEYCODE_$($a[0].ToUpperInvariant())"; Start-Sleep -Milliseconds 800 }
+    'back'       { Adb shell input keyevent KEYCODE_BACK; Start-Sleep -Milliseconds 1000 }
+    'swipe'      { if ($a[0]) { Cmd-Swipe $a[0] } else { Cmd-Swipe } }
+    'scroll-to'  { Cmd-ScrollTo ($a -join ' ') }
+    'wait-for'   { $secs = 30; $txt = $a -join ' '
+                   if ($a.Count -gt 1 -and $a[-1] -match '^\d+$') { $secs = [int]$a[-1]; $txt = ($a[0..($a.Count - 2)] -join ' ') }
+                   Cmd-WaitFor $txt $secs }
+    'flyout'     { Cmd-Flyout }
+    'search'     { Cmd-Search }
+    'goto'       { Cmd-Goto ($a -join ' ') }
+    'logcat'     { if ($a[0]) { Cmd-Logcat ([int]$a[0]) } else { Cmd-Logcat } }
+    'applog'     { Cmd-AppLog }
+    default      { Write-Host "Unknown command '$Command'`n"; Cmd-Help; exit 1 }
+}

--- a/.github/workflows/ci-build-and-preview.yml
+++ b/.github/workflows/ci-build-and-preview.yml
@@ -12,6 +12,21 @@ name: CI Build & UI Preview
 on:
   pull_request:
     branches: [main]
+    # This workflow costs a full MAUI build plus an emulator boot (~20-30 min), so
+    # skip it for changes that cannot affect the app. GitHub skips the run only when
+    # EVERY changed file matches one of these, so a PR touching both docs and src/
+    # still builds.
+    #
+    # Deliberately NOT ignored: .github/** (workflow edits should be validated by
+    # running) and .editorconfig (it carries analyzer rules, and the build must stay
+    # at zero warnings).
+    paths-ignore:
+      - ".claude/**"
+      - "**/*.md"
+      - "StoreImages/**"
+      - "screenshots/**"
+      - ".gitignore"
+      - ".gitattributes"
 
 permissions:
   contents: write

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,7 @@ pwsh tools/Get-OpenPrComments.ps1
 
 Requires `gh` CLI authenticated (or `GH_TOKEN` env var). See `.claude/skills/ani-pr-feedback/SKILL.md` (`/ani-pr-feedback`) for the full evaluation workflow.
 
-Project slash commands (`/ani-debug`, `/ani-review`, `/ani-pr-feedback`, `/project-architecture`, `/airing-notifications`) live in `.claude/skills/`.
+Project slash commands (`/ani-kickoff`, `/run-anisprinkles`, `/ani-debug`, `/ani-review`, `/ani-pr-feedback`, `/project-architecture`, `/airing-notifications`) live in `.claude/skills/`.
 
 ## Working with AI Agents
 

--- a/README.md
+++ b/README.md
@@ -95,4 +95,4 @@ dotnet build src/AniSprinkles.csproj -c Debug -f net10.0-android -p:EmbedAssembl
 | ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------- |
 | [`AGENTS.md`](AGENTS.md)                   | Architecture reference, conventions, build commands, and AI agent instructions                                             |
 | [`DEVELOPER_NOTES.md`](DEVELOPER_NOTES.md) | Local dev notes: error simulation, troubleshooting tips                                                                    |
-| [`.claude/skills/`](.claude/skills/)       | Workflow slash commands: `/ani-debug`, `/ani-review`, `/ani-pr-feedback`, `/project-architecture`, `/airing-notifications` |
+| [`.claude/skills/`](.claude/skills/)       | Workflow slash commands: `/ani-kickoff`, `/run-anisprinkles`, `/ani-debug`, `/ani-review`, `/ani-pr-feedback`, `/project-architecture`, `/airing-notifications` |


### PR DESCRIPTION
## Summary

Two new workflow skills under `.claude/skills/`, both exercised against real targets rather than written from the docs, plus a CI trigger change so this kind of PR stops paying for a full app build.

**`/run-anisprinkles`** — the app is Android-only, so there was previously no repeatable way to *see* a change working; every check meant an ad-hoc adb session. `driver.ps1` wraps adb + uiautomator behind subcommands (`up`, `tap`, `tap-desc`, `type`, `scroll-to`, `shot`, `logcat`, `applog`). The important one is `dump`, which prints every visible text/content-desc node so the screen is readable as text without inspecting pixels.

**`/ani-kickoff`** — takes issue numbers, verifies the issue isn't stale or already shipped, analyzes solutions independently of whatever the issue proposes, surfaces tradeoffs, asks clarifying questions, agrees a plan, then cuts the branch. Stops short of implementing.

**CI** — `ci-build-and-preview.yml` now carries `paths-ignore` for `.claude/**`, `**/*.md`, `StoreImages/**`, `screenshots/**`, and the two git dotfiles. A full MAUI build plus emulator boot is ~20-30 minutes, and none of those paths can affect the app. `.github/**` and `.editorconfig` are deliberately still built — workflow edits should be validated by running, and `.editorconfig` carries the analyzer rules behind the zero-warning requirement. GitHub skips a run only when *every* changed file matches, so a PR touching both docs and `src/` still builds. `main` has no branch protection, so a skipped run cannot block a merge.

## Verification

**run-anisprinkles** — built the CI-stub APK, booted `pixel_9 - api 36`, installed, launched, and drove a real flow end to end: My Anime → ONE PIECE details → favorite toggle (heart filled, Favourites 90,457 → 90,458). Then followed `SKILL.md` line by line from a clean shell; every code block in it is a command that ran.

**ani-kickoff** — run live against four issues. It found that #56 was retracted 70 seconds after filing *and* that all four of its items have since shipped; that #62 blocks the highest-value half of #52; and that #112's premise breaks on Release builds, where the file log persists only `Warning+` while every diagnostic trace (`NAVTRACE`, `PageState`, `CACHE`, `AUTH`) is `Information`.

**Triggering** — 20 sample phrasings routed correctly (10 fire, 10 stay quiet), including near-misses belonging to `/ani-pr-feedback`, `/ani-debug`, `/run-anisprinkles`, and `/project-architecture`.

## Review feedback addressed

- **Issue comments were never rendered.** The `ani-kickoff` Step 1 template printed only a comment count while the next line said to read them. It now renders every comment body — #56's status and #52's open design question exist *only* in their threads, so a count was worse than useless.
- **`boot` reused the wrong emulator.** It matched any online emulator, so `boot <other-avd>` silently no-opped and later commands drove the wrong device. Now it matches on AVD name and waits for `sys.boot_completed` even on reuse. Verified: with a Pixel 9 up, `boot television_4k_-_api_34_0` starts the TV image at `emulator-5556` rather than no-opping.
- **Silent boot timeout.** The wait loop fell through as success; it now throws.
- **No `-s` device targeting.** A second attached device broke every command with adb's bare "more than one device/emulator". All calls now route through a serial resolved from `ANDROID_SERIAL` or a lone attached device, and ambiguity names both devices and their AVDs. Verified with two emulators running.
- **Stale heading** referencing a branch that has since merged, retitled.

## Notes

- Both skills registered in the `AGENTS.md` and `README.md` skill lists.
- `driver.ps1` gotchas documented in its `SKILL.md`: two Android SDKs installed with PATH pointing at the one lacking the API 36 image, Git Bash rewriting `/sdcard` paths, `adb install` printing `Failure` while exiting 0, and screenshots corrupting if piped through a PowerShell redirect.
- No app code changes — tooling, CI config, and docs only.
